### PR TITLE
Fix dependency on Kapua client SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,18 @@
         <!-- https://mvnrepository.com/artifact/de.dentrassi.kapua/karaf -->
         <dependency>
             <groupId>de.dentrassi.kapua</groupId>
-            <artifactId>karaf</artifactId>
+            <artifactId>kapua-gateway-client-provider-mqtt-fuse</artifactId>
             <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>de.dentrassi.kapua</groupId>
+            <artifactId>kapua-gateway-client-profile-kura</artifactId>
+            <version>0.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
This change does use the two requires JAR dependencies from the Kapua
Gateway Client SDK instead of the Karaf bundle. It also adds logback
to the test scope in order to have consolidated logging when running
tests.